### PR TITLE
ci: initial Packit configuration

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -25,6 +25,8 @@ actions:
     # We need to call autogen, since we use a custom tarball
     - "sed -i '/^### Dependencies/aBuildRequires: bison' .packit_rpm/util-linux.spec"
     - "sed -i '/^unset LINGUAS/a./autogen.sh' .packit_rpm/util-linux.spec"
+    # Enable tests after build
+    - "sed -i '/^### Macros/a%define _with_check 1' .packit_rpm/util-linux.spec"
   create-archive:
     # We need to override the default create-archive action, since we need to tweak
     # the resulting tarball and add a .tarball-version file to it, otherwise

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,56 @@
+---
+# vi:ts=2 sw=2 et:
+#
+# Docs: https://packit.dev/docs/
+
+specfile_path: .packit_rpm/util-linux.spec
+synced_files:
+  - .packit.yaml
+  - src: .packit_rpm/util-linux.spec
+    dest: util-linux.spec
+upstream_package_name: util-linux
+downstream_package_name: util-linux
+# `git describe` returns in util-linux's case 'v2.37.2-xxx' which breaks RPM version
+# # detection (that expects 2.37.2-xxx'). Let's tweak the version string accordingly
+upstream_tag_template: "v{version}"
+
+actions:
+  post-upstream-clone:
+    # Use the CentOS Stream specfile
+    - "git clone https://gitlab.com/redhat/centos-stream/rpms/util-linux.git .packit_rpm --depth=1"
+    # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
+    - "rm -fv .packit_rpm/sources"
+    # Drop all patches, since they're already included in the tarball
+    - "sed -ri '/^Patch[0-9]+:/d' .packit_rpm/util-linux.spec"
+    # We need to call autogen, since we use a custom tarball
+    - "sed -i '/^### Dependencies/aBuildRequires: bison' .packit_rpm/util-linux.spec"
+    - "sed -i '/^unset LINGUAS/a./autogen.sh' .packit_rpm/util-linux.spec"
+  create-archive:
+    # We need to override the default create-archive action, since we need to tweak
+    # the resulting tarball and add a .tarball-version file to it, otherwise
+    # util-linux fails to detect its version during build
+    - "bash -c 'echo $PACKIT_PROJECT_VERSION >.tarball-version'"
+    - "bash -c 'git archive --prefix ${PACKIT_PROJECT_NAME_VERSION}/ --add-file .tarball-version --output .packit_rpm/${PACKIT_PROJECT_NAME_VERSION}.tar.gz HEAD'"
+    - "bash -c 'echo .packit_rpm/${PACKIT_PROJECT_NAME_VERSION}.tar.gz'"
+
+# Available targets can be listed via `copr-cli list-chroots`
+jobs:
+# Build test
+- job: copr_build
+  trigger: commit
+  metadata:
+    branch: rhel-9
+    targets:
+      # FIXME: change to CentOS 9 once it's available
+      - fedora-34-aarch64
+      - fedora-34-ppc64le
+      - fedora-34-x86_64
+
+# TODO: configure TFT
+# Run tests (via testing farm)
+#- job: tests
+#  trigger: pull_request
+#  metadata:
+#    targets:
+#      # FIXME: change to CentOS 9 once it's available
+#      - fedora-34-x86_64

--- a/include/pathnames.h
+++ b/include/pathnames.h
@@ -41,7 +41,7 @@
 #ifndef _PATH_MAILDIR
 # define _PATH_MAILDIR		"/var/spool/mail"
 #endif
-#define	_PATH_MOTDFILE		"/usr/share/misc/motd:/run/motd:/etc/motd"
+#define	_PATH_MOTDFILE		"/usr/share/misc/motd:/run/motd:/run/motd.d:/etc/motd:/etc/motd.d"
 #ifndef _PATH_NOLOGIN
 # define _PATH_NOLOGIN		"/etc/nologin"
 #endif

--- a/login-utils/login.c
+++ b/login-utils/login.c
@@ -662,7 +662,7 @@ static void log_lastlog(struct login_context *cxt)
 	sa.sa_handler = SIG_IGN;
 	sigaction(SIGXFSZ, &sa, &oldsa_xfsz);
 
-	fd = open(_PATH_LASTLOG, O_RDWR, 0);
+	fd = open(_PATH_LASTLOG, O_RDWR | O_CREAT, 0);
 	if (fd < 0)
 		goto done;
 	offset = cxt->pwd->pw_uid * sizeof(ll);

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -165,7 +165,7 @@ OPTS="$OPTS --srcdir=$top_srcdir --builddir=$top_builddir"
 if [ -z "$has_asan_opt" ]; then
         if [ -e "$top_builddir/Makefile" ]; then
 	    asan=$(awk '/^ASAN_LDFLAGS/ { print $3 }' $top_builddir/Makefile)
-        else
+        elif [ -f "$top_builddir/meson.conf" ]; then
             . "$top_builddir/meson.conf"
         fi
 	if [ -n "$asan" ]; then

--- a/tests/ts/eject/umount
+++ b/tests/ts/eject/umount
@@ -83,6 +83,7 @@ mkfs.ext2 -q -F $TS_DEVICE
 udevadm settle
 mkdir -p $TS_MOUNTPOINT
 $TS_CMD_MOUNT $TS_DEVICE $TS_MOUNTPOINT
+udevadm settle
 $TS_CMD_EJECT --force $TS_DEVICE && ts_log "Success"
 deinit_device
 ts_finalize_subtest
@@ -95,6 +96,7 @@ mkdir -p ${TS_MOUNTPOINT}1
 mkdir -p ${TS_MOUNTPOINT}2
 $TS_CMD_MOUNT ${TS_DEVICE}1 ${TS_MOUNTPOINT}1
 $TS_CMD_MOUNT ${TS_DEVICE}2 ${TS_MOUNTPOINT}2
+udevadm settle
 $TS_CMD_EJECT --force $TS_DEVICE && ts_log "Success"
 deinit_device
 ts_finalize_subtest
@@ -115,6 +117,7 @@ mkdir -p ${TS_MOUNTPOINT}1
 mkdir -p ${TS_MOUNTPOINT}2
 $TS_CMD_MOUNT ${TS_DEVICE}1 ${TS_MOUNTPOINT}1
 $TS_CMD_MOUNT ${TS_DEVICE}2 ${TS_MOUNTPOINT}2
+udevadm settle
 $TS_CMD_EJECT --force ${TS_DEVICE}1 && ts_log "Success"
 deinit_device
 ts_finalize_subtest

--- a/tests/ts/mount/fstab-all
+++ b/tests/ts/mount/fstab-all
@@ -79,6 +79,7 @@ echo  "${TS_DEVICE}4 ${MOUNTPOINT}D ext4 rw,defaults 0 0" >> $MY_FSTAB
 ts_init_subtest "basic"
 $TS_CMD_MOUNT --all --fstab $MY_FSTAB >> $TS_OUTPUT 2>> $TS_ERRLOG
 [ $? == 0 ] || ts_log "mount failed"
+udevadm settle
 $TS_CMD_UMOUNT ${MOUNTPOINT}{A,B,C,D}
 [ $? == 0 ] || ts_log "umount failed"
 ts_finalize_subtest
@@ -87,6 +88,7 @@ ts_finalize_subtest
 ts_init_subtest "filter-type"
 $TS_CMD_MOUNT --all --fstab $MY_FSTAB -t ext4 >> $TS_OUTPUT 2>> $TS_ERRLOG
 [ $? == 0 ] || ts_log "mount failed"
+udevadm settle
 $TS_CMD_UMOUNT ${MOUNTPOINT}D
 [ $? == 0 ] || ts_log "umount failed"
 ts_finalize_subtest
@@ -95,6 +97,7 @@ ts_finalize_subtest
 ts_init_subtest "filter-notype"
 $TS_CMD_MOUNT --all --fstab $MY_FSTAB -t noext4 >> $TS_OUTPUT 2>> $TS_ERRLOG
 [ $? == 0 ] || ts_log "mount failed"
+udevadm settle
 $TS_CMD_UMOUNT ${MOUNTPOINT}{A,B,C}
 [ $? == 0 ] || ts_log "umount failed"
 ts_finalize_subtest
@@ -103,6 +106,7 @@ ts_finalize_subtest
 ts_init_subtest "filter-option"
 $TS_CMD_MOUNT --all --fstab $MY_FSTAB -O ro >> $TS_OUTPUT 2>> $TS_ERRLOG
 [ $? == 0 ] || ts_log "mount failed"
+udevadm settle
 $TS_CMD_UMOUNT ${MOUNTPOINT}C
 [ $? == 0 ] || ts_log "umount failed"
 ts_finalize_subtest
@@ -111,6 +115,7 @@ ts_finalize_subtest
 ts_init_subtest "override-option"
 $TS_CMD_MOUNT --all --fstab $MY_FSTAB -o ro >> $TS_OUTPUT 2>> $TS_ERRLOG
 [ $? == 0 ] || ts_log "mount failed"
+udevadm settle
 $TS_CMD_UMOUNT ${MOUNTPOINT}{A,B,C,D}
 [ $? == 0 ] || ts_log "umount failed"
 ts_finalize_subtest
@@ -132,6 +137,7 @@ $TS_CMD_MOUNT	--all \
 		--target-prefix $MY_ROOT \
 		-o X-mount.mkdir >> $TS_OUTPUT 2>> $TS_ERRLOG
 [ $? == 0 ] || ts_log "mount failed"
+udevadm settle
 $TS_CMD_UMOUNT $MY_ROOT/foo/{A,B,C,D}
 [ $? == 0 ] || ts_log "umount failed"
 ts_finalize_subtest


### PR DESCRIPTION
Enable a basic set of Packit jobs to build util-linux RPMs from a
RHEL9/C9S specfile - on F34 for now, until we have public C9S images
available in Copr.

Some comments to the sed magic in the yaml configuration file:

1) We have to create a custom tarball by our own means, since the
   default Packit action doesn't include the necessary .tarball-version
   file. This wouldn't be necessary if we could use the `make distcheck`
   target, but the default builder chroot is missing some dependencies
   (like bison), so we have to fallback to `git archive`.

2) Consequently, we need to call autogen.sh from the specfile (normally
   we'd call it before `make distcheck` and already have a configure
   binary in the tarball)

3) Also consequently, explicitly run the `check` RPM phase during
   rpmbuild (by setting `_with_check 1`). This would be, also, normally
   executed by `make distcheck`.

As requested, run the checks on push events into the rhel-9 branch
instead of for each pull request.

This workflow can be later extended to send the built RPMs to the
Testing Farm (TFT)[0] for a more extensive testing.

[0] https://packit.dev/docs/testing-farm/
